### PR TITLE
Minimal Earthfile to get kong-build-tools Earthfile to work

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,0 +1,24 @@
+
+FROM alpine:3.13
+
+source:
+    WORKDIR /source
+    COPY --dir * ./
+    SAVE ARTIFACT /source/*
+
+requirements:
+    WORKDIR /reqs
+    COPY ./.requirements /reqs/
+    SAVE ARTIFACT /reqs/.requirements
+
+sha:
+    WORKDIR /sha
+    ARG EARTHLY_GIT_HASH
+    RUN echo "$EARTHLY_GIT_HASH" >./sha
+    SAVE ARTIFACT ./sha
+
+version:
+    WORKDIR /version
+    COPY ./kong-*.rockspec /version/
+    RUN echo ./kong-*.rockspec | sed 's,.*/,,' | cut -d- -f2 > ./version
+    SAVE ARTIFACT ./version


### PR DESCRIPTION
## THIS IS A DEMO / POC. DO NOT MERGE.

Re https://github.com/Kong/kong-build-tools/issues/381

<!--
NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch,
and ensure you followed them all:
https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#contributing
-->

### Summary

Part of an experimentation with the [Earthly](https://earthly.dev) build tool. This Earthfile doesn't do much on its own, but it is used by the `kong-build-tools` Earthfile to import source code, dependency info and version info.
